### PR TITLE
Use archive.apache.org instead for more stable download URI

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     },
     "npm-install-fetch": {
         "name":    "Apache Tika Server CLI 1.23",
-        "input":   "http://www.apache.org/dist/tika/tika-server-1.23.jar",
+        "input":   "http://archive.apache.org/dist/tika/tika-server-1.23.jar",
         "output":  "tika-server-cli.jar"
     }
 }


### PR DESCRIPTION
Currently, the build process fetches the upstream `tika-server` binary from `www.apache.org`, which only keeps the most recent release. This means the build process breaks whenever upstream releases a new version.

By using `archive.apache.org`, which keeps all previous releases as well as the current release, the build process should be less fragile.